### PR TITLE
feat: Initial attempt to create Nautobot n8n node

### DIFF
--- a/n8n-nodes-nautobot/README.md
+++ b/n8n-nodes-nautobot/README.md
@@ -1,0 +1,145 @@
+# Nautobot Node for n8n
+
+This repository contains a custom n8n node for interacting with Nautobot, an open-source Network Source of Truth and Network Automation Platform. This node allows you to integrate Nautobot into your n8n workflows to automate tasks related to network device management, data retrieval, and more.
+
+## Installation
+
+There are a few ways to install this node:
+
+1.  **NPM Install (Recommended for published packages):**
+    If this package is published to npm, you can install it by running the following command in your n8n user directory (typically `~/.n8n/custom/`):
+    ```bash
+    npm install n8n-nodes-nautobot
+    ```
+
+2.  **Manual Installation (for development or local use):**
+    - Clone this repository:
+      ```bash
+      git clone https://github.com/your-repo/n8n-nodes-nautobot.git
+      ```
+    - Build the node:
+      ```bash
+      cd n8n-nodes-nautobot
+      npm install
+      npm run build
+      ```
+    - Copy the built `dist` folder and `package.json` into your n8n custom nodes directory:
+      ```bash
+      # Example:
+      mkdir -p ~/.n8n/custom/n8n-nodes-nautobot
+      cp -r dist package.json ~/.n8n/custom/n8n-nodes-nautobot/
+      ```
+    Or, you can link the package if you are actively developing:
+      ```bash
+      # In the n8n-nodes-nautobot directory
+      npm link
+      # In your n8n custom nodes directory (~/.n8n/custom/)
+      npm link n8n-nodes-nautobot
+      ```
+
+3.  **Docker:**
+    If you are using Docker, you can build a custom image that includes this node. Refer to the n8n documentation for instructions on adding custom nodes to Docker.
+
+**Prerequisites:**
+- n8n version 1.0.0 or later.
+
+After installation, restart your n8n instance to see the Nautobot node available in the editor.
+
+## Configuration
+
+To use the Nautobot node, you need to configure credentials to allow it to authenticate with your Nautobot instance.
+
+1.  **Add New Credential:**
+    - In n8n, go to the "Credentials" section.
+    - Click "Add credential".
+    - Search for "Nautobot API" and select it.
+
+2.  **Configure Credential Fields:**
+    - **Nautobot URL**: The base URL of your Nautobot instance (e.g., `https://nautobot.example.com`). Do not include `/api` in this URL.
+    - **API Token**: Your Nautobot API token. You can generate this from your Nautobot user profile.
+
+    ![Example of Nautobot Credential Setup](https://via.placeholder.com/400x200.png?text=Nautobot+Credential+Example)
+    *(Note: Replace placeholder image with an actual screenshot if available)*
+
+## Supported Operations
+
+Currently, the Nautobot node supports the following operations:
+
+### Get Device
+
+-   **Operation Name**: `Get Device`
+-   **Description**: Retrieves a single device from Nautobot by its unique ID.
+-   **Input Parameters**:
+    -   `deviceId` (String): The UUID of the device to retrieve from Nautobot. This is a required field for this operation.
+-   **Output**:
+    -   Returns a JSON object representing the full details of the specified device. If the device is not found, it may return an empty result or an error, depending on the API's behavior and node error handling.
+
+    **Example Workflow Snippet:**
+    *(Imagine an n8n workflow diagram here showing an input node providing a deviceId, connected to the Nautobot node configured for 'Get Device', outputting to a Code node or another service.)*
+
+## Dependencies
+
+### Runtime Dependencies:
+
+The node relies on the following core n8n packages:
+-   `n8n-core`: Provides core functionalities for n8n nodes.
+-   `n8n-workflow`: Provides workflow-related functionalities.
+
+### Development Dependencies:
+
+For development and contribution, the following are key dependencies:
+-   `typescript`: For writing the node in TypeScript.
+-   `@types/node`: TypeScript definitions for Node.js.
+-   `eslint` & `prettier`: For code linting and formatting.
+-   `jest` & `ts-jest`: For running unit tests.
+
+## Development
+
+If you wish to contribute to this node or modify it:
+
+1.  **Clone the repository:**
+    ```bash
+    git clone https://github.com/your-repo/n8n-nodes-nautobot.git
+    cd n8n-nodes-nautobot
+    ```
+
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+
+3.  **Build the node:**
+    The node is written in TypeScript and needs to be compiled to JavaScript.
+    ```bash
+    npm run build
+    ```
+    This will compile the TypeScript files from `src` into the `dist` directory.
+
+4.  **Watch for changes (development mode):**
+    To automatically recompile the node when you make changes to the source files:
+    ```bash
+    npm run dev
+    ```
+
+5.  **Linting and Formatting:**
+    ```bash
+    npm run lint  # Check for linting errors
+    npm run format # Automatically format code
+    ```
+
+6.  **Testing:**
+    Run unit tests using Jest:
+    ```bash
+    npm run test
+    ```
+
+7.  **Link for local n8n testing:**
+    Follow the "Manual Installation" linking steps mentioned above to test your local changes in your n8n instance.
+
+## License
+
+This project is licensed under the MIT License. See the `LICENSE` file for details (if a separate LICENSE file is added, otherwise, specify here).
+
+---
+
+*This documentation is a work in progress and will be updated as more features are added to the node.*

--- a/n8n-nodes-nautobot/package.json
+++ b/n8n-nodes-nautobot/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "n8n-nodes-nautobot",
+  "version": "0.1.0",
+  "description": "n8n node for Nautobot",
+  "author": "n8n",
+  "license": "MIT",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "lint": "eslint src/**/*.ts",
+    "format": "prettier --write src/**/*.ts",
+    "test": "jest"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.ts$",
+    "moduleFileExtensions": [
+      "ts",
+      "js",
+      "json",
+      "node"
+    ]
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "n8n-community-node-package",
+    "nautobot"
+  ],
+  "n8n": {
+    "n8nNodesApiVersion": 1,
+    "credentials": [
+      "dist/credentials/NautobotApi.credentials.js"
+    ],
+    "nodes": [
+      "dist/nodes/Nautobot/Nautobot.node.js"
+    ]
+  },
+  "dependencies": {
+    "n8n-core": "^1.0.0",
+    "n8n-workflow": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^18.0.0",
+    "@typescript-eslint/parser": "~5.45",
+    "eslint": "~8.28",
+    "eslint-plugin-n8n-nodes-rules": "^1.0.0",
+    "prettier": "~2.8",
+    "typescript": "~4.8.4",
+    "jest": "^29.0.0",
+    "@types/jest": "^29.0.0",
+    "ts-jest": "^29.0.0"
+  }
+}

--- a/n8n-nodes-nautobot/src/credentials/NautobotApi.credentials.ts
+++ b/n8n-nodes-nautobot/src/credentials/NautobotApi.credentials.ts
@@ -1,0 +1,29 @@
+import {
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class NautobotApi implements ICredentialType {
+	name = 'nautobotApi';
+	displayName = 'Nautobot API';
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Nautobot URL',
+			name: 'apiUrl',
+			type: 'string',
+			default: '',
+			placeholder: 'https://nautobot.example.com',
+			description: 'The base URL of the Nautobot instance (e.g., https://nautobot.example.com)',
+			required: true,
+		},
+		{
+			displayName: 'API Token',
+			name: 'token',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			description: 'The API token for Nautobot',
+			required: true,
+		},
+	];
+}

--- a/n8n-nodes-nautobot/src/nodes/Nautobot/Nautobot.node.test.ts
+++ b/n8n-nodes-nautobot/src/nodes/Nautobot/Nautobot.node.test.ts
@@ -1,0 +1,140 @@
+import { IExecuteFunctions, INodeExecutionData, NodeApiError, NodeOperationError } from 'n8n-workflow';
+import { Nautobot } from './Nautobot.node';
+import { NautobotApiClient } from '../../services/NautobotApiClient';
+
+// Mock NautobotApiClient
+jest.mock('../../services/NautobotApiClient');
+
+const MockedNautobotApiClient = NautobotApiClient as jest.MockedClass<typeof NautobotApiClient>;
+
+describe('NautobotNode', () => {
+	let executeFunctions: IExecuteFunctions;
+	let node: Nautobot;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+
+		// Mock IExecuteFunctions
+		executeFunctions = {
+			getCredentials: jest.fn().mockResolvedValue({
+				apiUrl: 'http://localhost:8000',
+				token: 'testToken',
+			}),
+			getNodeParameter: jest.fn(),
+			helpers: {
+				returnJsonArray: jest.fn((data) => [{ json: data } as INodeExecutionData]), // Simplified mock
+			},
+			getNode: jest.fn().mockReturnValue({
+				// Mock basic node structure needed for errors
+				getName: () => 'Nautobot Node',
+				getExecutionId: () => 'exec-id-123',
+				getContext: (key: string) => ({ itemIndex: key === 'itemIndex' ? 0 : undefined } as any),
+			}),
+			continueOnFail: jest.fn().mockReturnValue(false),
+		} as unknown as IExecuteFunctions;
+
+		node = new Nautobot();
+	});
+
+	describe('execute', () => {
+		it("should call NautobotApiClient.getDevice and return data for 'getDevice' operation", async () => {
+			const deviceId = 'device-id-123';
+			const mockDeviceData = { id: deviceId, name: 'Test Device' };
+
+			(executeFunctions.getNodeParameter as jest.Mock)
+				.mockReturnValueOnce('getDevice') // operation
+				.mockReturnValueOnce(deviceId); // deviceId
+
+			const getDeviceMock = jest.fn().mockResolvedValue(mockDeviceData);
+			MockedNautobotApiClient.prototype.getDevice = getDeviceMock;
+
+			const result = await node.execute.call(executeFunctions);
+
+			expect(executeFunctions.getCredentials).toHaveBeenCalledWith('nautobotApi');
+			expect(MockedNautobotApiClient).toHaveBeenCalledWith(
+				'http://localhost:8000',
+				'testToken',
+				executeFunctions,
+			);
+			expect(getDeviceMock).toHaveBeenCalledWith(deviceId);
+			expect(executeFunctions.helpers.returnJsonArray).toHaveBeenCalledWith([mockDeviceData]);
+			expect(result).toEqual([{ json: [mockDeviceData] }]);
+		});
+
+		it('should throw NodeOperationError if deviceId is not provided for getDevice operation', async () => {
+			(executeFunctions.getNodeParameter as jest.Mock)
+				.mockReturnValueOnce('getDevice') // operation
+				.mockReturnValueOnce(undefined); // deviceId (missing)
+
+			await expect(node.execute.call(executeFunctions)).rejects.toThrow(NodeOperationError);
+			expect(MockedNautobotApiClient.prototype.getDevice).not.toHaveBeenCalled();
+		});
+
+		it('should throw NodeOperationError for an unsupported operation', async () => {
+			(executeFunctions.getNodeParameter as jest.Mock).mockReturnValueOnce('unsupportedOperation');
+
+			await expect(node.execute.call(executeFunctions)).rejects.toThrow(NodeOperationError);
+			expect(MockedNautobotApiClient.prototype.getDevice).not.toHaveBeenCalled();
+		});
+
+		it('should throw NodeApiError if NautobotApiClient.getDevice throws an error', async () => {
+			const deviceId = 'device-id-456';
+			const apiErrorMessage = 'API Error: Device not found';
+
+			(executeFunctions.getNodeParameter as jest.Mock)
+				.mockReturnValueOnce('getDevice') // operation
+				.mockReturnValueOnce(deviceId); // deviceId
+
+			const getDeviceMock = jest.fn().mockRejectedValue(new Error(apiErrorMessage));
+			MockedNautobotApiClient.prototype.getDevice = getDeviceMock;
+			// Simulate AxiosError structure for more precise error handling in the node
+			const axiosError = { isAxiosError: true, message: apiErrorMessage, response: { data: 'Not Found' } };
+			MockedNautobotApiClient.prototype.getDevice = jest.fn().mockRejectedValue(axiosError);
+
+
+			await expect(node.execute.call(executeFunctions)).rejects.toThrow(NodeApiError);
+			try {
+				await node.execute.call(executeFunctions);
+			} catch (e: any) {
+				expect(e).toBeInstanceOf(NodeApiError);
+				expect(e.message).toContain(`Nautobot API request failed: ${apiErrorMessage}`);
+			}
+
+			expect(getDeviceMock).toHaveBeenCalledWith(deviceId);
+		});
+
+		it('should return empty array if API returns undefined or null', async () => {
+			const deviceId = 'device-id-789';
+			(executeFunctions.getNodeParameter as jest.Mock)
+				.mockReturnValueOnce('getDevice')
+				.mockReturnValueOnce(deviceId);
+
+			MockedNautobotApiClient.prototype.getDevice = jest.fn().mockResolvedValue(null);
+			const result = await node.execute.call(executeFunctions);
+			expect(executeFunctions.helpers.returnJsonArray).toHaveBeenCalledWith([]);
+			expect(result).toEqual([{ json: [] }]);
+
+			MockedNautobotApiClient.prototype.getDevice = jest.fn().mockResolvedValue(undefined);
+			const result2 = await node.execute.call(executeFunctions);
+			expect(executeFunctions.helpers.returnJsonArray).toHaveBeenCalledWith([]);
+			expect(result2).toEqual([{ json: [] }]);
+		});
+
+		it('should return error data if continueOnFail is true and API client throws error', async () => {
+			const deviceId = 'device-id-error';
+			const errorMessage = 'API Failure';
+			(executeFunctions.getNodeParameter as jest.Mock)
+				.mockReturnValueOnce('getDevice')
+				.mockReturnValueOnce(deviceId);
+
+			(executeFunctions.continueOnFail as jest.Mock).mockReturnValue(true);
+			MockedNautobotApiClient.prototype.getDevice = jest.fn().mockRejectedValue(new Error(errorMessage));
+
+			const result = await node.execute.call(executeFunctions);
+
+			expect(executeFunctions.helpers.returnJsonArray).toHaveBeenCalledWith([{ error: errorMessage }]);
+			expect(result).toEqual([{ json: [{ error: errorMessage }] }]);
+		});
+
+	});
+});

--- a/n8n-nodes-nautobot/src/nodes/Nautobot/Nautobot.node.ts
+++ b/n8n-nodes-nautobot/src/nodes/Nautobot/Nautobot.node.ts
@@ -1,0 +1,101 @@
+import { IExecuteFunctions } from 'n8n-core';
+import {
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+	NodeApiError,
+	NodeOperationError,
+} from 'n8n-workflow';
+import { NautobotApiClient } from '../../services/NautobotApiClient';
+
+export class Nautobot implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Nautobot',
+		name: 'nautobot',
+		icon: 'file:nautobot.svg',
+		group: ['transform'],
+		version: 1,
+		description: 'Interact with Nautobot API',
+		defaults: {
+			name: 'Nautobot Node',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		credentials: [
+			{
+				name: 'nautobotApi',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Get Device',
+						value: 'getDevice',
+						description: 'Get a device by ID',
+						action: 'Get a device by id',
+					},
+				],
+				default: 'getDevice',
+				description: 'The operation to perform.',
+			},
+			{
+				displayName: 'Device ID',
+				name: 'deviceId',
+				type: 'string',
+				default: '',
+				required: true,
+				displayOptions: {
+					show: {
+						operation: ['getDevice'],
+					},
+				},
+				description: 'The ID of the device to retrieve.',
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const operation = this.getNodeParameter('operation', 0) as string;
+		const credentials = await this.getCredentials('nautobotApi');
+		const nautobotApiUrl = credentials.apiUrl as string; // Changed 'url' to 'apiUrl'
+		const token = credentials.token as string;
+
+		const apiClient = new NautobotApiClient(nautobotApiUrl, token, this);
+
+		try {
+			let result: any;
+			if (operation === 'getDevice') {
+				const deviceId = this.getNodeParameter('deviceId', 0) as string;
+				if (!deviceId) {
+					throw new NodeOperationError(this.getNode(), 'Device ID is required for getDevice operation.');
+				}
+				result = await apiClient.getDevice(deviceId);
+			} else {
+				throw new NodeOperationError(this.getNode(), `Unsupported operation: ${operation}`);
+			}
+
+			if (result === undefined || result === null) {
+				return [this.helpers.returnJsonArray([])];
+			}
+
+			return [this.helpers.returnJsonArray([result])];
+
+		} catch (error) {
+			if (this.continueOnFail()) {
+				return [this.helpers.returnJsonArray([{ error: error.message }])];
+			}
+			// Check if it's an error from the API client (e.g. network error)
+			if (error.isAxiosError) { // AxiosError would have this property
+				throw new NodeApiError(this.getNode(), error, { message: `Nautobot API request failed: ${error.message}` });
+			}
+			// For other errors (e.g., operational errors within the node)
+			throw new NodeOperationError(this.getNode(), `Error executing Nautobot node: ${error.message}`, { itemIndex: 0 });
+		}
+	}
+}

--- a/n8n-nodes-nautobot/src/nodes/Nautobot/nautobot.svg.placeholder
+++ b/n8n-nodes-nautobot/src/nodes/Nautobot/nautobot.svg.placeholder
@@ -1,0 +1,12 @@
+An SVG icon for Nautobot is needed here.
+The icon should be relevant to Nautobot, for example, its logo or a stylized representation of network devices.
+The icon file should be named `nautobot.svg` and placed in this directory.
+The `icon` property in `Nautobot.node.ts` should be `file:nautobot.svg`.
+
+For example, a simple SVG could be:
+<svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="60" height="60" rx="8" fill="#007bff"/>
+<text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial" font-size="12" fill="white">Nautobot</text>
+</svg>
+
+Please replace this placeholder file with the actual `nautobot.svg`.

--- a/n8n-nodes-nautobot/src/services/NautobotApiClient.test.ts
+++ b/n8n-nodes-nautobot/src/services/NautobotApiClient.test.ts
@@ -1,0 +1,160 @@
+import { IExecuteFunctions, IHttpRequestOptions } from 'n8n-workflow';
+import { NautobotApiClient } from './NautobotApiClient';
+
+// Mock IExecuteFunctions
+const mockExecuteFunctions = {
+	helpers: {
+		request: jest.fn(),
+	},
+} as unknown as IExecuteFunctions;
+
+describe('NautobotApiClient', () => {
+	let client: NautobotApiClient;
+	const baseUrl = 'http://localhost:8000';
+	const token = 'testToken';
+
+	beforeEach(() => {
+		// Reset mocks before each test
+		jest.clearAllMocks();
+		client = new NautobotApiClient(baseUrl, token, mockExecuteFunctions);
+	});
+
+	describe('constructor', () => {
+		it('should correctly initialize with base URL and token', () => {
+			expect(client['baseUrl']).toBe(baseUrl); // Accessing private member for test
+			expect(client['token']).toBe(token);
+		});
+
+		it('should remove trailing slash from baseUrl', () => {
+			const clientWithTrailingSlash = new NautobotApiClient(
+				baseUrl + '/',
+				token,
+				mockExecuteFunctions,
+			);
+			expect(clientWithTrailingSlash['baseUrl']).toBe(baseUrl);
+		});
+	});
+
+	describe('apiRequest', () => {
+		it('should make a GET request with correct headers and URL', async () => {
+			const endpoint = '/dcim/devices/';
+			const expectedUrl = `${baseUrl}/api${endpoint}`;
+			const mockResponseData = { id: 'device1' };
+			(mockExecuteFunctions.helpers.request as jest.Mock).mockResolvedValueOnce(
+				mockResponseData,
+			);
+
+			const result = await client['apiRequest']('GET', endpoint); // Accessing private method
+
+			expect(mockExecuteFunctions.helpers.request).toHaveBeenCalledTimes(1);
+			const requestOptions = (mockExecuteFunctions.helpers.request as jest.Mock)
+				.mock.calls[0][0] as IHttpRequestOptions;
+			expect(requestOptions.method).toBe('GET');
+			expect(requestOptions.url).toBe(expectedUrl);
+			expect(requestOptions.headers?.['Authorization']).toBe(`Token ${token}`);
+			expect(requestOptions.headers?.['Content-Type']).toBe('application/json');
+			expect(requestOptions.headers?.['Accept']).toBe('application/json');
+			expect(requestOptions.body).toBeUndefined();
+			expect(requestOptions.qs).toBeUndefined();
+			expect(result).toEqual(mockResponseData);
+		});
+
+		it('should include body for POST/PUT requests', async () => {
+			const endpoint = '/dcim/devices/';
+			const body = { name: 'New Device' };
+			(mockExecuteFunctions.helpers.request as jest.Mock).mockResolvedValueOnce({});
+
+			await client['apiRequest']('POST', endpoint, body); // Accessing private method
+
+			expect(mockExecuteFunctions.helpers.request).toHaveBeenCalledTimes(1);
+			const requestOptions = (mockExecuteFunctions.helpers.request as jest.Mock)
+				.mock.calls[0][0] as IHttpRequestOptions;
+			expect(requestOptions.body).toEqual(body);
+		});
+
+		it('should include query string for GET requests if provided', async () => {
+			const endpoint = '/dcim/devices/';
+			const qs = { site: 'ams01' };
+			(mockExecuteFunctions.helpers.request as jest.Mock).mockResolvedValueOnce([]);
+
+			await client['apiRequest']('GET', endpoint, undefined, qs); // Accessing private method
+
+			expect(mockExecuteFunctions.helpers.request).toHaveBeenCalledTimes(1);
+			const requestOptions = (mockExecuteFunctions.helpers.request as jest.Mock)
+				.mock.calls[0][0] as IHttpRequestOptions;
+			expect(requestOptions.qs).toEqual(qs);
+		});
+
+		it('should throw error if API request fails', async () => {
+			const endpoint = '/dcim/devices/';
+			const errorMessage = 'Network Error';
+			(mockExecuteFunctions.helpers.request as jest.Mock).mockRejectedValueOnce(
+				new Error(errorMessage),
+			);
+
+			await expect(client['apiRequest']('GET', endpoint)).rejects.toThrow(errorMessage);
+		});
+	});
+
+	describe('getDevice', () => {
+		const deviceId = 'test-device-id';
+		const endpoint = `/dcim/devices/${deviceId}/`;
+
+		it('should call apiRequest with correct parameters and return device data', async () => {
+			const mockDeviceData = { id: deviceId, name: 'Test Device' };
+			(mockExecuteFunctions.helpers.request as jest.Mock).mockResolvedValueOnce(
+				mockDeviceData,
+			);
+
+			const result = await client.getDevice(deviceId);
+
+			expect(mockExecuteFunctions.helpers.request).toHaveBeenCalledTimes(1);
+			const requestOptions = (mockExecuteFunctions.helpers.request as jest.Mock)
+				.mock.calls[0][0] as IHttpRequestOptions;
+			expect(requestOptions.method).toBe('GET');
+			expect(requestOptions.url).toBe(`${baseUrl}/api${endpoint}`);
+			expect(result).toEqual(mockDeviceData);
+		});
+
+		it('should throw an error if the API call fails', async () => {
+			const errorMessage = 'API Error: Device not found';
+			(mockExecuteFunctions.helpers.request as jest.Mock).mockRejectedValueOnce(
+				new Error(errorMessage),
+			);
+
+			await expect(client.getDevice(deviceId)).rejects.toThrow(errorMessage);
+			expect(mockExecuteFunctions.helpers.request).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('listDevices', () => {
+		const endpoint = '/dcim/devices/';
+		it('should call apiRequest with correct parameters and return list of devices', async () => {
+			const mockDevicesData = [{ id: 'device1' }, { id: 'device2' }];
+			(mockExecuteFunctions.helpers.request as jest.Mock).mockResolvedValueOnce(
+				mockDevicesData,
+			);
+			const params = { site: 'ams01' };
+			const result = await client.listDevices(params);
+
+			expect(mockExecuteFunctions.helpers.request).toHaveBeenCalledTimes(1);
+			const requestOptions = (mockExecuteFunctions.helpers.request as jest.Mock)
+				.mock.calls[0][0] as IHttpRequestOptions;
+
+			expect(requestOptions.method).toBe('GET');
+			expect(requestOptions.url).toBe(`${baseUrl}/api${endpoint}`);
+			expect(requestOptions.qs).toEqual(params);
+			expect(result).toEqual(mockDevicesData);
+		});
+
+		it('should throw an error if the API call fails', async () => {
+			const errorMessage = 'API Error: Unauthorized';
+			(mockExecuteFunctions.helpers.request as jest.Mock).mockRejectedValueOnce(
+				new Error(errorMessage),
+			);
+
+			await expect(client.listDevices()).rejects.toThrow(errorMessage);
+			expect(mockExecuteFunctions.helpers.request).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/n8n-nodes-nautobot/src/services/NautobotApiClient.ts
+++ b/n8n-nodes-nautobot/src/services/NautobotApiClient.ts
@@ -1,0 +1,67 @@
+import { IDataObject, IHttpRequestOptions } from 'n8n-workflow';
+import { IExecuteFunctions } from 'n8n-core';
+
+export class NautobotApiClient {
+	private baseUrl: string;
+	private token: string;
+	private executeFunctions: IExecuteFunctions;
+
+	constructor(
+		baseUrl: string,
+		token: string,
+		executeFunctions: IExecuteFunctions,
+	) {
+		this.baseUrl = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
+		this.token = token;
+		this.executeFunctions = executeFunctions;
+	}
+
+	private async apiRequest(
+		method: string,
+		endpoint: string,
+		body?: IDataObject,
+		qs?: IDataObject,
+	): Promise<any> {
+		const options: IHttpRequestOptions = {
+			method,
+			url: `${this.baseUrl}/api${endpoint}`,
+			headers: {
+				'Authorization': `Token ${this.token}`,
+				'Content-Type': 'application/json',
+				'Accept': 'application/json',
+			},
+			body,
+			qs,
+			json: true,
+		};
+
+		try {
+			const response = await this.executeFunctions.helpers.request(options);
+			return response;
+		} catch (error) {
+			// Log the error or handle it as needed
+			throw error;
+		}
+	}
+
+	async getDevice(id: string): Promise<any> {
+		return this.apiRequest('GET', `/dcim/devices/${id}/`);
+	}
+
+	async listDevices(params?: IDataObject): Promise<any> {
+		return this.apiRequest('GET', '/dcim/devices/', undefined, params);
+	}
+
+	// Placeholder for other methods like createDevice, updateDevice, deleteDevice, etc.
+	// async createDevice(data: IDataObject): Promise<any> {
+	// 	return this.apiRequest('POST', '/dcim/devices/', data);
+	// }
+
+	// async updateDevice(id: string, data: IDataObject): Promise<any> {
+	// 	return this.apiRequest('PUT', `/dcim/devices/${id}/`, data);
+	// }
+
+	// async deleteDevice(id: string): Promise<any> {
+	// 	return this.apiRequest('DELETE', `/dcim/devices/${id}/`);
+	// }
+}

--- a/n8n-nodes-nautobot/tsconfig.json
+++ b/n8n-nodes-nautobot/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
This reflects an attempt to initialize and develop an n8n node for Nautobot. Unfortunately, due to an accidental reset, the progress was lost.

My original plan was as follows:
1. Initialize the n8n node project (create structure, package.json, tsconfig.json).
2. Define node properties and metadata (in Nautobot.node.ts).
3. Implement the Nautobot API client (NautobotApiClient.ts).
4. Implement core node functionality (execute method in Nautobot.node.ts).
5. Add credential types (NautobotApi.credentials.ts).
6. Write unit tests (for API client and node).
7. Create documentation (README.md, package.json updates).
8. Conduct an initial review and commit the changes.

Here's what I managed to do before the reset:
- I successfully initialized the project structure.
- I defined the node properties and metadata.
- I implemented a basic API client.
- I implemented the 'getDevice' operation in the node's execute method.
- I defined the credential type.
- I wrote comprehensive unit tests for the client and node.
- I created initial documentation (README.md) and updated package.json.

I encountered some challenges:
- I had persistent issues with the build environment, specifically running the TypeScript compiler (`tsc`) via `npm` scripts or `npx`. This made it difficult to compile, test, and verify changes reliably.
- An accidental reset erased all project files, forcing me to restart the process.

This commit serves as a baseline for me to re-attempt the task. The primary obstacle remains the build environment stability for TypeScript projects.